### PR TITLE
Add support for configuration of browserSync middleware

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,0 +1,16 @@
+const config = {}
+
+export function set(name, value)
+{
+  config[name] = value
+}
+
+export function get(name)
+{
+  return config[name]
+}
+
+export function clear(name)
+{
+  config[name] = null
+}

--- a/gulp/dev.js
+++ b/gulp/dev.js
@@ -11,6 +11,8 @@ import run from "run-sequence"
 
 import { $, logChange, devServer } from "./common"
 
+import { get as getConfig } from "./config"
+
 gulp.task("build", (done) =>
   run("vue:split", [ "css:build", "js:build" ], done)
 )
@@ -48,7 +50,8 @@ gulp.task("serve", () =>
     port: 8085,
     server: {
       baseDir: "./src"
-    }
+    },
+    middleware: getConfig("browserSync.middleware")
   })
 )
 


### PR DESCRIPTION
This introduces a global build configuration with support for adding
middleware to browserSync, e.g. http-proxy-middleware

The introduction of a global config store can be a subject for discussion.

We use it as

````
import proxyMiddleware from "http-proxy-middleware
import requireDir from "require-dir"

const gulpModules = requireDir("gulp")
gulpModules.config.set("browserSync.middleware", [
  proxyMiddleware(...)
])
````
to proxy backend requests without having CORS problems.